### PR TITLE
Cleaner assignment to `$this->whiteIps`

### DIFF
--- a/Listener/SoftLockListener.php
+++ b/Listener/SoftLockListener.php
@@ -17,7 +17,7 @@ class SoftLockListener
     {
         $this->maintenancePage = $maintenancePage;
         $this->lock = file_exists($maintenanceLock);
-        $this->whiteIps = $this->whiteIps;
+        $this->whiteIps = $whiteIps;
 
         array_walk($whitePaths, function(&$elem) {
             $elem = "/" . str_replace("/", "\\/", $elem) . "/";

--- a/Listener/SoftLockListener.php
+++ b/Listener/SoftLockListener.php
@@ -24,7 +24,6 @@ class SoftLockListener
         });
 
         $this->whitePaths = array_replace(array("/^\/_/"), $whitePaths);
-        $this->whiteIps = array_replace(array(), $whiteIps);
     }
 
     public function setRequestStack($requestStack)


### PR DESCRIPTION
As noticed by @Obernado, the `$this->whiteIps = $this->whiteIps` line, as is, is pointless.  This patch does the same assignment as the `$this->whiteIps = array_replace(array(), $whiteIps)` line in a less uselessly obscure way.
