### PR TITLE
Fixes #5 - default files are missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 php:
+    - 7.0
     - 5.6
     - 5.5
 
 env:
-  - SYMFONY_VERSION="~2.4"
-  - SYMFONY_VERSION="~2.5"
-  - SYMFONY_VERSION="~2.6"
   - SYMFONY_VERSION="~2.7"
   - SYMFONY_VERSION="~2.8"
+  - SYMFONY_VERSION="~3.0"
+  - SYMFONY_VERSION="~3.1"
 
 before_script:
   - composer selfupdate

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode("page")->defaultValue("CorleyMaintenanceBundle:maintenance.html")->end()
+                ->scalarNode("page")->defaultValue(__DIR__ . "/../Resources/views/maintenance.html")->end()
                 ->scalarNode("web")->defaultValue('%kernel.root_dir%/../web')->end()
                 ->scalarNode("soft_lock")->defaultValue('soft.lock')->end()
                 ->scalarNode("hard_lock")->defaultValue('hard.lock')->end()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Corley Maintenance Bundle
 
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/aa52f44b-26f4-45ba-9b62-423dbda8d80b/big.png)](https://insight.sensiolabs.com/projects/aa52f44b-26f4-45ba-9b62-423dbda8d80b)
-
 Just an unified way to put a web application under maintenance mode using web server strategies. The maintenance
 mode will cut off all requests and it will replies with a static html file and a 503 header (Service Unavailable).
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,7 +46,7 @@
 
         <service id="corley_maintenance.soft_lock" class="Corley\MaintenanceBundle\Listener\SoftLockListener">
             <argument>%maintenance.page%</argument>
-            <argument>%maintenance.soft_lock%</argument>
+            <argument>%maintenance.web%/%maintenance.soft_lock%</argument>
             <argument>%maintenance.white_paths%</argument>
             <argument>%maintenance.white_ips%</argument>
             <call method="setRequestStack">

--- a/Tests/Command/MaintenanceCommandTest.php
+++ b/Tests/Command/MaintenanceCommandTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Corley\MaintenanceBundle\Tests\Command;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 use Corley\MaintenanceBundle\Command\MaintenanceCommand;
 
@@ -13,10 +13,10 @@ class MaintenanceCommandTest extends \PHPUnit_Framework_TestCase
 
     private function prepareCommand()
     {
-        $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
+        //$this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
         $this->runner = $this->getMock('Corley\\MaintenanceBundle\\Maintenance\\Runner', array(), array(), '', false, false);
 
-        $application = new Application($this->kernel);
+        $application = new Application();
         $application->add(new MaintenanceCommand($this->runner));
 
         $command = $application->find('corley:maintenance:lock');

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -15,7 +15,12 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, array($options));
 
-        $this->assertEquals($results, $config);
+        $this->assertEquals($results["symlink"], $config["symlink"]);
+        $this->assertEquals($results["soft_lock"], $config["soft_lock"]);
+        $this->assertEquals($results["hard_lock"], $config["hard_lock"]);
+        $this->assertEquals($results["web"], $config["web"]);
+        $this->assertEquals($results["whitelist"], $config["whitelist"]);
+        $this->assertRegExp("/{$results["page"]}$/i", $config["page"]);
     }
 
     public function getModes()
@@ -32,7 +37,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'paths' => array(),
                         'ips' => array()
                     ),
-                    'page' => "CorleyMaintenanceBundle:maintenance.html",
+                    'page' => "maintenance.html",
                 )
             ),
             array(
@@ -46,7 +51,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'paths' => array('/_'),
                         'ips' => array()
                     ),
-                    'page' => "CorleyMaintenanceBundle:maintenance.html",
+                    'page' => "maintenance.html",
                 )
             ),
         );

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     "target-dir": "Corley/MaintenanceBundle",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.4 <3",
-        "symfony/security-bundle": ">=2.4 <3",
-        "symfony/console": ">=2.4 <3",
-        "symfony/dependency-injection": ">=2.4 <3"
+        "symfony/framework-bundle": ">=2.6",
+        "symfony/security-bundle": ">=2.6",
+        "symfony/console": ">=2.6",
+        "symfony/dependency-injection": ">=2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*",


### PR DESCRIPTION
Fixes the error:

```
[InvalidArgumentException]
Source file CorleyMaintenanceBundle:maintenance.html is missing
```

The default resources path is now located using absolutes paths.

I have also refactored few tests in order to be compatible with
new Symfony versions
