### PR TITLE
improve documentation

### DIFF
--- a/Command/DumpApacheConfCommand.php
+++ b/Command/DumpApacheConfCommand.php
@@ -27,16 +27,19 @@ EOF
         $output->writeln(<<<EOF
 Open your .htaccess file and paste those lines before any other rewrite rule:
 
-    RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
-    RewriteCond %{SCRIPT_FILENAME} !{$container->getParameter("maintenance.hard_lock")}
-    RewriteRule ^.*$ /{$container->getParameter("maintenance.hard_lock")} [R=503,L]
+    <IfModule mod_rewrite.c>
+      RewriteEngine on
+      RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
+      RewriteCond %{SCRIPT_FILENAME} !{$container->getParameter("maintenance.hard_lock")}
+      RewriteRule ^.*$ /{$container->getParameter("maintenance.hard_lock")} [R=503,L]
 
-    RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
-    RewriteRule ^(.*)$ - [env=MAINTENANCE:1]
+      RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
+      RewriteRule ^(.*)$ - [env=MAINTENANCE:1]
 
-    <IfModule mod_headers.c>
+      <IfModule mod_headers.c>
         Header set cache-control "max-age=0,must-revalidate,post-check=0,pre-check=0" env=MAINTENANCE
         Header set Expires -1 env=MAINTENANCE
+      </IfModule>
     </IfModule>
 
     ErrorDocument 503 /{$container->getParameter("maintenance.hard_lock")}

--- a/Command/DumpApacheConfCommand.php
+++ b/Command/DumpApacheConfCommand.php
@@ -25,7 +25,7 @@ EOF
         $container = $this->getContainer();
 
         $output->writeln(<<<EOF
-Open your .htaccess file and paste those lines:
+Open your .htaccess file and paste those lines before any other rewrite rule:
 
     RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
     RewriteCond %{SCRIPT_FILENAME} !{$container->getParameter("maintenance.hard_lock")}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ app/console corley:maintenance:lock off
 
 If you use Apache2 you have to add few lines to your `.htaccess`, in case of nginx just add dedicated
 lines to web app configuration.
+Make sure that those lines precede any other rewrite rule.
+The `mod_rewrite` module in Apache2 has to be installed and enabled.
 
 In order to obtain your configuration options just use the console
 

--- a/README.md
+++ b/README.md
@@ -96,3 +96,14 @@ application must works in order to lock down the web site.
 
 The soft lock runs at `kernel.request` and stop other event propagations.
 
+When you want to put your web application under maintenance using a soft-locking strategy:
+
+```shell
+bin/console corley:maintenance:soft-lock on
+```
+
+Restore the application status
+
+```shell
+bin/console corley:maintenance:soft-lock off
+```

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ public function registerBundles()
 When you want to put your web application under maintenance
 
 ```shell
-app/console corley:maintenance:lock on
+bin/console corley:maintenance:lock on
 ```
 
 Restore the application status
 
 ```shell
-app/console corley:maintenance:lock off
+bin/console corley:maintenance:lock off
 ```
 
 ## Configure your web server
@@ -58,12 +58,12 @@ In order to obtain your configuration options just use the console
 ### Apache2
 
 ```shell
-app/console corley:maintenance:dump-apache
+bin/console corley:maintenance:dump-apache
 ```
 ### Nginx
 
 ```shell
-app/console corley:maintenance:dump-nginx
+bin/console corley:maintenance:dump-nginx
 ```
 
 ## Configuration


### PR DESCRIPTION
This should help new users to use this bundle with less effort. For example, tell them that rewrite rules should precede others, and how they can activate a soft-lock.
Minor improvement for Symfony3, which uses bin/console instead of app/console.
