### PR TITLE
Make tree builder with root node (fix deprecation)

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -8,9 +8,15 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('corley_maintenance');
 
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('corley_maintenance');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('corley_maintenance');
+        }
+        
         $rootNode
             ->children()
                 ->scalarNode("page")->defaultValue(__DIR__ . "/../Resources/views/maintenance.html")->end()


### PR DESCRIPTION
Make tree builder with root node (fix deprecation in symfony 4.2) and maintain backwards compatibility

@wdalmut Please check.