### PR TITLE
Symfony 5 fatal error with dump commands

### DIFF
--- a/Command/DumpApacheConfCommand.php
+++ b/Command/DumpApacheConfCommand.php
@@ -1,12 +1,25 @@
 <?php
 namespace Corley\MaintenanceBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DumpApacheConfCommand extends ContainerAwareCommand
+class DumpApacheConfCommand extends Command
 {
+    protected $hardLock;
+
+    /**
+     * DumpApacheConfCommand constructor.
+     * @param string $hardLock
+     */
+    public function __construct(string $hardLock)
+    {
+        parent::__construct(null);
+        $this->hardLock = $hardLock;
+    }
+
+
     protected function configure()
     {
         $this
@@ -22,18 +35,16 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container = $this->getContainer();
-
         $output->writeln(<<<EOF
 Open your .htaccess file and paste the following lines before any other rewrite rules:
 
     <IfModule mod_rewrite.c>
       RewriteEngine on
-      RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
-      RewriteCond %{SCRIPT_FILENAME} !{$container->getParameter("maintenance.hard_lock")}
-      RewriteRule ^.*$ /{$container->getParameter("maintenance.hard_lock")} [R=503,L]
+      RewriteCond %{DOCUMENT_ROOT}/{$this->hardLock} -f
+      RewriteCond %{SCRIPT_FILENAME} !{$this->hardLock}
+      RewriteRule ^.*$ /{$this->hardLock} [R=503,L]
 
-      RewriteCond %{DOCUMENT_ROOT}/{$container->getParameter("maintenance.hard_lock")} -f
+      RewriteCond %{DOCUMENT_ROOT}/{$this->hardLock} -f
       RewriteRule ^(.*)$ - [env=MAINTENANCE:1]
 
       <IfModule mod_headers.c>
@@ -42,9 +53,11 @@ Open your .htaccess file and paste the following lines before any other rewrite 
       </IfModule>
     </IfModule>
 
-    ErrorDocument 503 /{$container->getParameter("maintenance.hard_lock")}
+    ErrorDocument 503 /{$this->hardLock}
 
 EOF
         );
+
+        return 0;
     }
 }

--- a/Command/DumpNginxConfCommand.php
+++ b/Command/DumpNginxConfCommand.php
@@ -1,12 +1,25 @@
 <?php
 namespace Corley\MaintenanceBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DumpNginxConfCommand extends ContainerAwareCommand
+class DumpNginxConfCommand extends Command
 {
+    protected $hardLock;
+
+    /**
+     * DumpNginxConfCommand constructor.
+     * @param $hardLock
+     */
+    public function __construct($hardLock)
+    {
+        parent::__construct(null);
+        $this->hardLock = $hardLock;
+    }
+
+
     protected function configure()
     {
         $this
@@ -22,13 +35,11 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $container = $this->getContainer();
-
         $output->writeln(<<<EOF
 Open your site configuration file and paste the following lines:
 
     location / {
-        if (-f \$document_root/{$container->getParameter("maintenance.hard_lock")}) {
+        if (-f \$document_root/{$this->hardLock}) {
             return 503;
         }
 
@@ -39,10 +50,12 @@ Open your site configuration file and paste the following lines:
     location @maintenance {
         expires           0;
         add_header        Cache-Control private;
-        rewrite ^(.*)$ /{$container->getParameter("maintenance.hard_lock")} break;
+        rewrite ^(.*)$ /{$this->hardLock} break;
     }
 
 EOF
         );
+
+        return 0;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,11 +46,13 @@
 
         <service id="corley_maintenance.command.dump_apache_command"
                  class="Corley\MaintenanceBundle\Command\DumpApacheConfCommand">
+            <argument>%maintenance.hard_lock%</argument>
             <tag name="console.command" />
         </service>
 
         <service id="corley_maintenance.command.dump_nginx_command"
                  class="Corley\MaintenanceBundle\Command\DumpNginxConfCommand">
+            <argument>%maintenance.hard_lock%</argument>
             <tag name="console.command" />
         </service>
 

--- a/Tests/Command/DumpCommandTest.php
+++ b/Tests/Command/DumpCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Corley\MaintenanceBundle\Tests\Command;
+
+use Corley\MaintenanceBundle\Command\DumpNginxConfCommand;
+use Corley\MaintenanceBundle\Command\DumpApacheConfCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use \PHPUnit\Framework\TestCase;
+
+
+class DumpCommandTest extends TestCase
+{
+    private $hardLock = 'lock.html';
+
+    public function testDumpApacheConfig()
+    {
+        $application = new Application();
+        $application->add(new DumpApacheConfCommand($this->hardLock));
+
+        $command = $application->find('corley:maintenance:dump-apache');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertEquals($this->expectedApacheConfig(), trim($commandTester->getDisplay()));
+    }
+
+    public function testDumpNginxConfig()
+    {
+        $application = new Application();
+        $application->add(new DumpNginxConfCommand($this->hardLock));
+
+        $command = $application->find('corley:maintenance:dump-nginx');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertEquals($this->expectedNginxConfig(), trim($commandTester->getDisplay()));
+    }
+
+    private function expectedApacheConfig(): string
+    {
+        return <<<EOF
+Open your .htaccess file and paste the following lines before any other rewrite rules:
+
+    <IfModule mod_rewrite.c>
+      RewriteEngine on
+      RewriteCond %{DOCUMENT_ROOT}/{$this->hardLock} -f
+      RewriteCond %{SCRIPT_FILENAME} !{$this->hardLock}
+      RewriteRule ^.*$ /{$this->hardLock} [R=503,L]
+
+      RewriteCond %{DOCUMENT_ROOT}/{$this->hardLock} -f
+      RewriteRule ^(.*)$ - [env=MAINTENANCE:1]
+
+      <IfModule mod_headers.c>
+        Header set cache-control "max-age=0,must-revalidate,post-check=0,pre-check=0" env=MAINTENANCE
+        Header set Expires -1 env=MAINTENANCE
+      </IfModule>
+    </IfModule>
+
+    ErrorDocument 503 /{$this->hardLock}
+EOF;
+    }
+
+    private function expectedNginxConfig(): string
+    {
+        return <<<EOF
+Open your site configuration file and paste the following lines:
+
+    location / {
+        if (-f \$document_root/{$this->hardLock}) {
+            return 503;
+        }
+
+        ### the rest of your config goes here ###
+    }
+
+    error_page 503 @maintenance;
+    location @maintenance {
+        expires           0;
+        add_header        Cache-Control private;
+        rewrite ^(.*)$ /{$this->hardLock} break;
+    }
+EOF;
+    }
+}


### PR DESCRIPTION
Dump commands were still extending the now removed ContainerAwareCommand. Refactored for dependency injection of the necessary parameter.

Added tests for both dump commands.