### PR TITLE
Removing kernel.root_dir from config as it's been removed from SF 5.1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode("page")->defaultValue(__DIR__ . "/../Resources/views/maintenance.html")->end()
-                ->scalarNode("web")->defaultValue('%kernel.root_dir%/../web')->end()
+                ->scalarNode("web")->defaultValue('%kernel.project_dir%/public')->end()
                 ->scalarNode("soft_lock")->defaultValue('soft.lock')->end()
                 ->scalarNode("hard_lock")->defaultValue('hard.lock')->end()
                 ->booleanNode("symlink")->defaultFalse()->end()

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Those conditions will ensure that a load balancer cut an instance off during a m
 
 ## Install
 
-In `composer.json` add the requirement. The current version requires at least PHP 7.2 and a supported version of Symfony (3.4, 4.2, 4.3, 4.4 and 5.0). 
+In `composer.json` add the requirement. The current version requires at least PHP 7.2 and a supported version of Symfony (3.4, 4.4 and 5.1). 
 
 ```json
 "require": {
-    "corley/maintenance-bundle": "^0.3"
+    "corley/maintenance-bundle": "^0.4"
 }
 ```
 
@@ -24,7 +24,7 @@ To support earlier versions e.g. SF 2.x, 3.3, 4.1 etc or PHP less than 7.2 you w
     "corley/maintenance-bundle": "^0.2"
 }
 ```
-This version can also be used for more recent Symfony versions, e.g. with 3.4 or 4.4 but is not compatible with Symfony 5 - only `0.3` can be used there because of changes to the event structure in Symfony 5.0.
+This version can also be used for more recent Symfony versions, e.g. with 3.4 or 4.4 but is not compatible with Symfony 5 - only `0.3` or greater can be used there because of changes to the event structure in Symfony 5.0.
 
 
 For pre-Flex applications register the bundle in `AppKernel.php`
@@ -92,6 +92,7 @@ corley_maintenance:
     page: %kernel.root_dir%/../web/maintenance.dist.html
     hard_lock: lock.html
     symlink: false
+    web: %kernel.root_dir%/../web
 ```
 
 For Flex projects
@@ -108,9 +109,9 @@ Options:
 * `page` is the original maintenance page (default: `vendor/corley/maintenance-bundle/Corley/MaintenanceBundle/Resources/views/maintenance.html`)
 * `symlink` If you want to use symlinks instead hardcopy strategy (default: hardcopy)
 * `hard_lock` Is the name used in order to lock the website (default: `hard.lock`)
-* `web` public folder (default `web` folder, for Flex projects you will need to configure this for your public folder, i.e. `%kernel.project_dir%/public`)
+* `web` public folder. Prior to 0.4 this defaulted to `%kernel.root_dir%/../web`, since 0.4.0 the new default is `%kernel.project_dir%/public` as the `%kernel.root_dir%` parameter has been deprecated since Symfony 4.2, and was removed in 5.1. If your project's public folder is still `web` (or some other folder) set this in the config file.
 * `soft_lock` Is the name used in order to lock the website (using app layer)
-* `whitelist` Authorized connections [soft-lock only]
+* `whilelist` Authorized connections [soft-lock only]
   * `paths` A list of paths that skip the maintenance lock
   * `ips` A list of ips that skip the maintenance lock
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Options:
 * `hard_lock` Is the name used in order to lock the website (default: `hard.lock`)
 * `web` public folder. Prior to 0.4 this defaulted to `%kernel.root_dir%/../web`, since 0.4.0 the new default is `%kernel.project_dir%/public` as the `%kernel.root_dir%` parameter has been deprecated since Symfony 4.2, and was removed in 5.1. If your project's public folder is still `web` (or some other folder) set this in the config file.
 * `soft_lock` Is the name used in order to lock the website (using app layer)
-* `whilelist` Authorized connections [soft-lock only]
+* `whitelist` Authorized connections [soft-lock only]
   * `paths` A list of paths that skip the maintenance lock
   * `ips` A list of ips that skip the maintenance lock
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -33,7 +33,7 @@ class ConfigurationTest extends TestCase
                     'symlink' => false,
                     'soft_lock' => 'soft.lock',
                     'hard_lock' => 'hard.lock',
-                    'web' => '%kernel.root_dir%/../web',
+                    'web' => '%kernel.project_dir%/public',
                     'whitelist' => array(
                         'paths' => array(),
                         'ips' => array()
@@ -47,7 +47,7 @@ class ConfigurationTest extends TestCase
                     'symlink' => true,
                     'soft_lock' => 'soft.lock',
                     'hard_lock' => 'hard.lock',
-                    'web' => '%kernel.root_dir%/../web',
+                    'web' => '%kernel.project_dir%/public',
                     'whitelist' => array(
                         'paths' => array('/_'),
                         'ips' => array()


### PR DESCRIPTION
`kernel.root_dir` was deprecated in SF 4.2 and removed in 5.1 meaning that the default config was no-longer valid.